### PR TITLE
Add ability to match patterns within unmatched directories

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -22,6 +22,13 @@ in
     ];
   };
 
+  with-nestedMatches = nix-filter {
+    root = ./fixture1;
+    include = [
+      (nix-filter.matchExt "js")
+    ];
+  };
+
   trace = nix-filter {
     root = ./fixture1;
     include = [


### PR DESCRIPTION
**Opening this PR to start discussion, but I don't yet consider this ready to merge.**

## The Problem

This PR lifts the main limitation noted in the README, namely that a pattern/matcher won't match unless all its parent directories are also matched.

## The Solution

The approach I've taken to tackle this is as follows:

- Instead of passing raw matchers to `builtin.path`'s filter function, we build up a set of matched paths beforehand and the filter function just checks if the current path is in our set.
- This set of matched paths is built up in two ways:
    1. Manually traverse the file tree starting at the project root and accumulate the paths that succeed the matcher function tests.
    2. Expand all paths from step 1 as well as raw paths the user passes. This expansion takes a path and creates a list containing that path and all of its parent directories up to the root of the project. This makes all of a path's parents match as well, so the `filter` function will recurse into these directories and find our actual matches.

## Things That Still Need Work

- This completely breaks the `traceUnmatched` function.
- The manual matching traverses the file tree once for each matcher function. This is inefficient. It would be better if we could somehow compose matcher functions into one function and do a single pass over the file system.
- The manual matching traverses *every* path under the root, including large (and almost always unwanted) directories like `.git`. The tree traversal should be updated to respect the `excludes` list and not traverse excluded directories.