### PR TITLE
Make test cases runnable

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v13
+      - run: tests/run-tests.sh
+

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,66 +1,64 @@
 let
-  nix-filter = import ../.;
+  testCases = import ./tests.nix;
+
+  # Convert a path to a string with the root stripped
+  toRelativeString = root: path:
+    let
+      r = toString root;
+      p = toString path;
+    in
+    builtins.substring
+      (builtins.stringLength r + 1)
+      (builtins.stringLength p)
+      p;
+
+  # Traverse a directory, returning all children in a list
+  listDir =
+    root:
+    let
+      files = builtins.readDir root;
+      filesAsList = map (fileName:
+        {
+          path =  root + ("/" + fileName);
+          type = builtins.getAttr fileName files;
+        }
+      ) (builtins.attrNames files);
+      pathsInDir = map (file: file.path) filesAsList;
+      nestedPaths = builtins.concatMap (file: listDir file.path)
+        (builtins.filter (file: file.type == "directory") filesAsList);
+    in
+    pathsInDir ++ nestedPaths;
+
+  # Run a test, returning a list of failures
+  runTest = testDef:
+    let
+      missing = builtins.filter (file:
+        ! builtins.pathExists (testDef.actual + ("/" + file))
+      ) testDef.expected;
+      included = map (toRelativeString testDef.actual) (listDir testDef.actual);
+      extra = builtins.filter (path:
+        ! builtins.elem path testDef.expected
+      ) included;
+    in
+    (map (x: { path = x; status = "missing"; }) missing)
+    ++
+    (map (x: { path = x; status = "extra"; }) extra);
+
+  # Take a set of test results and filter out every key that
+  # is not failing.
+  onlyFailures = results:
+    let
+      names = builtins.attrNames results;
+    in
+    builtins.foldl' (finalFailures: testName:
+      let
+        failures = builtins.getAttr testName results;
+      in
+      if builtins.length failures == 0
+      then finalFailures
+      else finalFailures // { ${testName} = failures; }
+    ) {} names;
+
+  testResults = builtins.mapAttrs (_: testDef: runTest testDef) testCases;
 in
-{
-  all = nix-filter {
-    root = ./fixture1;
-  };
-
-  without-readme = nix-filter {
-    root = ./fixture1;
-    exclude = [
-      "README.md"
-    ];
-  };
-
-  with-matchExt = nix-filter {
-    root = ./fixture1;
-    include = [
-      "package.json"
-      "src"
-      (nix-filter.matchExt "js")
-    ];
-  };
-
-  with-matchExt2 = nix-filter {
-    root = ./fixture1;
-    include = [
-      "package.json"
-      "src/innerdir"
-      (nix-filter.matchExt "js")
-    ];
-  };
-
-  with-inDirectory = nix-filter {
-    root = ./fixture1;
-    include = [
-      (nix-filter.inDirectory "src") # should match everything under ./fixture1/src/
-      (nix-filter.inDirectory "READ") # should not match README.md
-    ];
-  };
-
-  # should match everything under ./fixture1/src/ but not in ./fixture1/src/innerdir/
-  with-inDirectory2 = nix-filter {
-    root = ./fixture1;
-    include = [
-      (nix-filter.inDirectory "src")
-    ];
-    exclude = [
-      (nix-filter.inDirectory ./fixture1/src/innerdir)
-    ];
-  };
-
-  combiners = nix-filter {
-    root = ./fixture1;
-    include = with nix-filter; [
-      (and isDirectory (inDirectory "src"))
-    ];
-  };
-
-  trace = nix-filter {
-    root = ./fixture1;
-    include = [
-      nix-filter.traceUnmatched
-    ];
-  };
-}
+testResults // { "@onlyFailures" = onlyFailures testResults; }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -17,12 +17,14 @@ let
     root:
     let
       files = builtins.readDir root;
-      filesAsList = map (fileName:
-        {
-          path =  root + ("/" + fileName);
-          type = builtins.getAttr fileName files;
-        }
-      ) (builtins.attrNames files);
+      filesAsList = map
+        (fileName:
+          {
+            path = root + ("/" + fileName);
+            type = builtins.getAttr fileName files;
+          }
+        )
+        (builtins.attrNames files);
       pathsInDir = map (file: file.path) filesAsList;
       nestedPaths = builtins.concatMap (file: listDir file.path)
         (builtins.filter (file: file.type == "directory") filesAsList);
@@ -32,13 +34,17 @@ let
   # Run a test, returning a list of failures
   runTest = testDef:
     let
-      missing = builtins.filter (file:
-        ! builtins.pathExists (testDef.actual + ("/" + file))
-      ) testDef.expected;
+      missing = builtins.filter
+        (file:
+          ! builtins.pathExists (testDef.actual + ("/" + file))
+        )
+        testDef.expected;
       included = map (toRelativeString testDef.actual) (listDir testDef.actual);
-      extra = builtins.filter (path:
-        ! builtins.elem path testDef.expected
-      ) included;
+      extra = builtins.filter
+        (path:
+          ! builtins.elem path testDef.expected
+        )
+        included;
     in
     (map (x: { path = x; status = "missing"; }) missing)
     ++
@@ -50,14 +56,17 @@ let
     let
       names = builtins.attrNames results;
     in
-    builtins.foldl' (finalFailures: testName:
-      let
-        failures = builtins.getAttr testName results;
-      in
-      if builtins.length failures == 0
-      then finalFailures
-      else finalFailures // { ${testName} = failures; }
-    ) {} names;
+    builtins.foldl'
+      (finalFailures: testName:
+        let
+          failures = builtins.getAttr testName results;
+        in
+        if builtins.length failures == 0
+        then finalFailures
+        else finalFailures // { ${testName} = failures; }
+      )
+      { }
+      names;
 
   testResults = builtins.mapAttrs (_: testDef: runTest testDef) testCases;
 in

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Our little test runner.
-#
+
 set -euo pipefail
 
 cd "$(dirname "$0")"
@@ -12,8 +12,77 @@ if [[ "$#" -eq 1 ]]; then
     extra_flags="-A $1"
 fi
 
-
 # Need to build first or the store paths don't exist
 # for default.nix to traverse
 nix-build &>/dev/null
-nix-instantiate --eval --strict --json $extra_flags
+results="$(nix-instantiate --eval --strict --json $extra_flags)"
+
+# Normalize input before handing it over to jq
+if [[ -n "$extra_flags" ]] && [[ "${1::1}" != "@" ]]; then
+    results="{ \"$1\": $results }"
+fi
+
+# Parse and format the results with jq
+#
+# This expects the JSON format to look like:
+#     { "test-case-name": [ { "path": "./path/to/file", "status": "missing" } ] }
+#
+# There is a special case ("@onlyFailures") which is a key with
+# the expected format nested inside of it. In order to not choke
+# on this "report" style of key, we filter out keys starting with
+# "@".
+result_string=$(
+    echo "$results" |\
+        jq -r '
+            "\\e[0;91m" as $red |
+            "\\e[0;92m" as $green |
+            "\\e[0m" as $reset |
+            to_entries |
+            map(select(.key|startswith("@") == false)) |
+                (
+                    map(
+                        (.value|length) as $errors |
+                        "TEST: " + .key + " " +
+                        (
+                            if $errors > 0
+                            then $red + "(" + ($errors|tostring) + " errors"
+                            else $green + "(SUCCESS" end
+                        ) +
+                        ")" + $reset + "\n" +
+                        ( .value |
+                            map(
+                                "  " +
+                                (
+                                    if .status == "missing"
+                                    then "MISSING "
+                                    else "EXTRA   " end
+                                ) +
+                                .path + "\n"
+                            ) | add
+                        )
+                    )|.[]
+                ),
+                (
+                    [ (map(select(.value|length > 0))|length)
+                    , (map(select(.value|length == 0))|length)
+                    ] |
+                    "Tests completed. " +
+                    (
+                        if .[1] > 0
+                        then $green + (.[1]|tostring) + " succeeded" + $reset + ". "
+                        else "" end
+                    ) +
+                    (
+                        if .[0] > 0
+                        then $red + (.[0]|tostring) + " failed" + $reset + "."
+                        else "" end
+                    )
+                )'
+)
+
+echo -e "$result_string"
+
+# If there are errors in the output, return a non-zero exit code
+if grep -Po "^TEST:.*?\(\d+ errors\)" <<< "$result_string" &>/dev/null; then
+    exit 1
+fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+extra_flags=""
+
+if [[ "$#" -eq 1 ]]; then
+    extra_flags="-A $1"
+fi
+
+
+# Need to build first or the store paths don't exist
+# for default.nix to traverse
+nix-build &>/dev/null
+nix-instantiate --eval --strict --json $extra_flags

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+#
+# Our little test runner.
+#
+set -euo pipefail
 
-set -e
+cd "$(dirname "$0")"
 
 extra_flags=""
 

--- a/tests/tests.nix
+++ b/tests/tests.nix
@@ -136,6 +136,6 @@ in
         nix-filter.traceUnmatched
       ];
     };
-    expected = [];
+    expected = [ ];
   };
 }

--- a/tests/tests.nix
+++ b/tests/tests.nix
@@ -1,0 +1,141 @@
+let
+  nix-filter = import ../.;
+in
+{
+  all = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+    };
+    expected = [
+      "README.md"
+      "package.json"
+      "src"
+      "src/main.js"
+      "src/components"
+      "src/components/widget.jsx"
+      "src/innerdir"
+      "src/innerdir/inner.js"
+    ];
+  };
+
+  without-readme = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      exclude = [
+        "README.md"
+      ];
+    };
+    expected = [
+      "package.json"
+      "src"
+      "src/main.js"
+      "src/components"
+      "src/components/widget.jsx"
+      "src/innerdir"
+      "src/innerdir/inner.js"
+    ];
+  };
+
+  with-matchExt = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = [
+        "package.json"
+        "src"
+        (nix-filter.matchExt "js")
+      ];
+    };
+    expected = [
+      "package.json"
+      "src"
+      "src/main.js"
+    ];
+  };
+
+  with-matchExt2 = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = [
+        "package.json"
+        "src/innerdir"
+        (nix-filter.matchExt "js")
+      ];
+    };
+    expected = [
+      "package.json"
+      "src"
+      "src/main.js"
+      "src/innerdir"
+      "src/innerdir/inner.js"
+    ];
+  };
+
+  with-inDirectory = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = [
+        (nix-filter.inDirectory "src")
+        (nix-filter.inDirectory "READ")
+      ];
+    };
+    expected = [
+      "src"
+      "src/main.js"
+      "src/components"
+      "src/components/widget.jsx"
+      "src/innerdir"
+      "src/innerdir/inner.js"
+    ];
+  };
+
+  with-inDirectory2 = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = [
+        (nix-filter.inDirectory "src")
+        (nix-filter.inDirectory "READ")
+      ];
+      exclude = [
+        (nix-filter.inDirectory ./fixture1/src/innerdir)
+      ];
+    };
+    expected = [
+      "src"
+      "src/main.js"
+      "src/components"
+      "src/components/widget.jsx"
+    ];
+  };
+
+  combiners = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = with nix-filter; [
+        (and isDirectory (inDirectory "src"))
+      ];
+    };
+    expected = [
+      "src"
+      "src/components"
+      "src/innerdir"
+    ];
+  };
+
+  trace = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = [
+        nix-filter.traceUnmatched
+      ];
+    };
+    expected = [];
+  };
+}


### PR DESCRIPTION
This is a fix for #6 .

It's implemented mostly in Nix, but could be changed into a shell script if that's preferable.

- All tests can be run with `./run-tests.sh`.
- An individual test can be specified: `./run-tests.sh with-inDirectory2`
- Can output only failing tests: `./run-tests.sh @onlyFailures`

Empty lists mean no failures occurred for that test case.