### PR TITLE
Don't match parents while excluding a path

### DIFF
--- a/tests/tests.nix
+++ b/tests/tests.nix
@@ -113,6 +113,47 @@ in
     ];
   };
 
+  excluding-paths-keeps-the-parents = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = with nix-filter; [
+        (inDirectory "src")
+      ];
+      exclude = with nix-filter; [
+        "src/components"
+        "src/innerdir/inner.js"
+      ];
+    };
+    expected = [
+      "src"
+      "src/innerdir"
+      "src/main.js"
+    ];
+  };
+
+  exclude-string-or-matchExt-and-inDirectory = rec {
+    root = ./fixture1;
+    actual = nix-filter {
+      inherit root;
+      include = with nix-filter; [
+        (inDirectory "src")
+      ];
+      exclude = with nix-filter; [
+        (or_
+          "src/components/widget.jsx"
+          (and (matchExt "js") (inDirectory "src/innerdir"))
+        )
+      ];
+    };
+    expected = [
+      "src"
+      "src/components"
+      "src/innerdir"
+      "src/main.js"
+    ];
+  };
+
   combiners = rec {
     root = ./fixture1;
     actual = nix-filter {


### PR DESCRIPTION
Given the following directory
```
$ tree
.
├── data
│   ├── a
│   ├── b
│   └── c
├── flake.lock
└── flake.nix
```
The following `nix-filter` call was producing an empty directory:
```
let
  inherit (nix-filter) inDirectory;
in
nix-filter {
  root = ./.;
  name = "test";
  include = [
    (inDirectory "data")
  ];
  exclude = [
    "data/a"
  ];
}
```
Because of this line
https://github.com/numtide/nix-filter/blob/3c9e33ed627e009428197b07216613206f06ed80/default.nix#L35

In essence, it is changed to
```
        path_ == path
        || args.matchParents
          && type == "directory"
          && _hasPrefix "${path}/" path_;
```

where `args.matchParents` is `true` for `include` and `false` for `exclude`. 