### PR TITLE
fix: oversight in debugMatch

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@ rec {
   debugMatch = label: fn:
     root: path: type:
       let
-        ret = fn path type;
+        ret = fn root path type;
         retStr = if ret then "true" else "false";
       in
       builtins.trace "label=${label} path=${path} type=${type} ret=${retStr}"


### PR DESCRIPTION
debugMatch has to pass the matcher transparently to its wrapped
matcher
