### PR TITLE
Fix toMatcher in matchParents mode

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -105,8 +105,7 @@ rec {
     else
       path: type:
         path_ == path || args.matchParents
-                          && type == "directory"
-                          && _hasPrefix "${path}/" path_;
+                          && _hasPrefix path_ (toString path);
 
   # Makes sure a path is:
   # * absolute


### PR DESCRIPTION
toMatcher's matchParents logic was broken: the order of arguments in hasPrefix was reversed from what it should be (at least if I understand the logic correctly). That meant that only the directories themselves were included, whereas the logic seems to suggest that all the elements in those directories are also supposed to be included.
